### PR TITLE
Allow users to configure TinyMCE to load on view

### DIFF
--- a/MW_tinymce.js
+++ b/MW_tinymce.js
@@ -328,4 +328,7 @@ window.mwTinyMCEInit = function( tinyMCESelector ) {
 	});
 };
 
-mwTinyMCEInit( '#wpTextbox1' );
+mwTinyMCEInit( '.tinymce, #wpTextbox1' );
+
+// Let others know we're done here
+$( document ).trigger( 'TinyMCELoaded' );

--- a/TinyMCE.hooks.php
+++ b/TinyMCE.hooks.php
@@ -446,6 +446,11 @@ class TinyMCEHooks {
 			return false;
 		}
 
+        global $wgTinyMCELoadOnView;
+        if ( Action::getActionName( $context ) === 'view') {
+            return (bool)$wgTinyMCELoadOnView;
+        }
+
 		return true;
 	}
 
@@ -499,6 +504,28 @@ class TinyMCEHooks {
 		}
 		return true;
 	}
+
+    /**
+     * Load the extension on every view, if allowed.
+     *
+     * @param OutputPage $output
+     * @return void
+     */
+    public static function addToViewPage( OutputPage &$output ) {
+        $context = $output->getContext();
+        $action = Action::getActionName( $context );
+
+        if ( $action != 'view' ) {
+            return;
+        }
+
+        if( self::enableTinyMCE( $output->getTitle(), $context ) ) {
+            $GLOBALS['wgTinyMCEEnabled'] = true;
+            $output->addModules( 'ext.tinymce' );
+        } else {
+            $GLOBALS['wgTinyMCEEnabled'] = false;
+        }
+    }
 
 	public static function addPreference( $user, &$preferences ) {
 		$preferences['tinymce-use'] = array(

--- a/extension.json
+++ b/extension.json
@@ -170,7 +170,8 @@
 		"EditPage::showEditForm:initial": "TinyMCEHooks::addToEditPage",
 		"WikiEditorDisable": "TinyMCEHooks::disableWikiEditor",
 		"GetPreferences": "TinyMCEHooks::addPreference",
-		"PageForms::addRLModules": "TinyMCEHooks::addRLModules"
+		"PageForms::addRLModules": "TinyMCEHooks::addRLModules",
+		"OutputPageBeforeHTML": "TinyMCEHooks::addToViewPage"
 	},
 	"Actions": {
 		"tinymceedit": "TinyMCEAction"
@@ -188,7 +189,8 @@
 		"TinyMCEPreservedTags": [],
 		"TinyMCEEnabled": false,
 		"TinyMCEDisabledNamespaces": [ 8, 10 ],
-		"TinyMCEUnhandledStrings": []
+		"TinyMCEUnhandledStrings": [],
+		"TinyMCELoadOnView": false
 	},
 	"manifest_version": 1
 }


### PR DESCRIPTION
This change would allow users to load the extension on the `view` action by setting `$wgTinyMCELoadOnView = true;`.

It will automatically convert any textarea with the class `tinymce` into a TinyMCE instance.