### PR TITLE
Fix paste issues

### DIFF
--- a/mediawiki/plugins/mw_upload/plugin.js
+++ b/mediawiki/plugins/mw_upload/plugin.js
@@ -948,7 +948,7 @@ tinymce.PluginManager.add('wikiupload', function(editor) {
 						uploadDetails = data.upload;
 					},
 					error:function(xhr,status, error){
-						uploadDetails.responseText = xhr.responseText;
+						uploadDetails['responseText'] = xhr.responseText;
 						console.log(error);
 					}
 				});


### PR DESCRIPTION
With this fix it should be possible to drag/drop or copy/paste from an html encoded document into the editor. When doing this, any image files (contained in 'img' tags) will be uploaded to the wiki and the html will be converted to point at the uploaded file. Links in the html (contained in 'a' tags with 'href' property) will be processed to include the equivalent wiki text as a data attribute which can be edited using the 'link' menu button.

With these changes, I now don't use the TinyMCE 'paste' plugin as it was stripping out some of the pasted html and I couldn't find a setting to stop this. When we move to TinyMCE 5 I'll try their 'paste' plugin again.

The usual caveats apply to pasted/dropped html. Because CSS definitions and wider html context may not be picked up by the copy/drag operation, what gets pasted/dropped may look different and behave differently to the original. Maybe Tiny MCE 5 will improve on this!
